### PR TITLE
fix: dev environment and account for broken jpype 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,16 @@ You can find `paquo`'s documentation at
 ## Installation
 
 paquo's stable releases can be installed via `pip`:
+
 ```bash
 pip install paquo
 ```
 
 or via `conda`:
+
 ```bash
 conda install -c conda-forge paquo
 ```
-
 
 ## Getting QuPath
 
@@ -68,17 +69,15 @@ paquo to use that version. Currently, paquo supports every version of QuPath fro
 /some/path/on/your/machine/QuPath-0.5.0
 ```
 
-
 ## Development Installation
 
 1. Install conda and git
 2. Clone paquo `git clone https://github.com/bayer-science-for-a-better-life/paquo.git`
-3. Run `conda env create -f environment.devenv.yaml`
+3. Run `conda env create -f environment.devenv.yml`
 4. Activate the environment `conda activate paquo`
 
 Note that in this environment `paquo` is already installed in development mode,
 so go ahead and hack.
-
 
 ## Contributing Guidelines
 
@@ -86,12 +85,11 @@ so go ahead and hack.
   - We allow 120 character long lines (try anyway to keep them short)
 - Please use [numpy docstrings](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard).
 - When contributing code, please try to use Pull Requests.
-- tests go hand in hand with modules on ```tests``` packages at the same level. We use ```pytest```.
+- tests go hand in hand with modules on `tests` packages at the same level. We use `pytest`.
 
 You can set up your IDE to help you to adhere to these guidelines.
 <br>
 _([Santi](https://github.com/sdvillal) is happy to help you to set up pycharm in 5 minutes)_
-
 
 ## Acknowledgements
 

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,26 +1,28 @@
 #
 # Conda devenv environment for paquo
 #
-# Create the environment, do not install pado in development mode:
+# Create the environment:
 #   conda devenv
-# equivalent to:
-#   PAQUO_DEVEL="" conda devenv
-# Create the environment, install pado in development mode:
-#   PAQUO_DEVEL=TRUE conda devenv
 #
-
-{% set PAQUO_DEVEL = os.environ.get('PAQUO_DEVEL', False) %}
-{% set WITH_OME = os.environ.get('WITH_OME', False) %}
 
 name: paquo
 
 channels:
   - conda-forge
+  - defaults
+
+variables:
+  PAQUO_DEVEL: $PAQUO_DEVEL
+  WITH_OME: $WITH_OME
+
+environment:
+  PAQUO_DEVEL: ${PAQUO_DEVEL:-false}
+  WITH_OME: ${WITH_OME:-false}
 
 dependencies:
   - python>=3.7
   - pip
-  - jpype1>=1.0.1
+  - jpype1>=1.0.1,!=1.5.1
   - dynaconf>=3,!=3.1.0,!=3.1.7
   - ome-types   # [ WITH_OME ]
   - shapely

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     dynaconf>=3,!=3.1.0
-    JPype1>=1.0.1
+    JPype1>=1.0.1,!=1.5.1
     shapely
     packaging
 


### PR DESCRIPTION
- fix broken dev env setup. Tested on macOS X Sonoma, freshly installed conda 24.9.2
- workaround broken jpype 1.5.1