### PR TITLE
Support 0.6.0 and more tests

### DIFF
--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -7,9 +7,6 @@ on:
     tags: v[0-9]+.[0-9]+.[0-9]+
   pull_request: {}
 
-env:
-  QUPATH_VERSION: 0.5.1
-
 jobs:
   # RUN PYTEST ON PAQUO SOURCE
   tests:
@@ -20,17 +17,37 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
+        qupath-version: ["0.6.0"]
         include:
           # we'll test the python support on ubuntu
           - os: ubuntu-latest
-            python-version: '3.11'
-          - os: ubuntu-latest
             python-version: '3.12'
+            qupath-version: '0.6.0'
+          - os: ubuntu-latest
+            python-version: '3.11'
+            qupath-version: '0.6.0'
+          - os: ubuntu-latest
+            python-version: '3.10'
+            qupath-version: '0.6.0'
           - os: ubuntu-latest
             python-version: '3.9'
+            qupath-version: '0.6.0'
           - os: ubuntu-latest
             python-version: '3.8'
+            qupath-version: '0.6.0'
+          - os: ubuntu-latest
+            python-version: '3.13'
+            qupath-version: '0.5.1'
+          - os: ubuntu-latest
+            python-version: '3.13'
+            qupath-version: '0.4.4'
+          - os: ubuntu-latest
+            python-version: '3.13'
+            qupath-version: '0.3.2'
+          - os: ubuntu-latest
+            python-version: '3.13'
+            qupath-version: '0.2.3'
     steps:
     - uses: actions/checkout@v3
       with:
@@ -49,13 +66,13 @@ jobs:
         CACHE_NUMBER: 0
       with:
         path: ./qupath/download
-        key: ${{ runner.os }}-qupath-v${{ env.CACHE_NUMBER }}
+        key: ${{ runner.os }}-qupath-v${{ matrix.qupath-version }}-c${{ env.CACHE_NUMBER }}
     - name: Install qupath and set PAQUO_QUPATH_DIR
       shell: bash
       run: |
         python -c "import os; os.makedirs('qupath/download', exist_ok=True)"
         python -c "import os; os.makedirs('qupath/apps', exist_ok=True)"
-        python -m paquo get_qupath --install-path ./qupath/apps --download-path ./qupath/download ${{ env.QUPATH_VERSION }} | grep -v "^#" | sed "s/^/PAQUO_QUPATH_DIR=/" >> $GITHUB_ENV
+        python -m paquo get_qupath --install-path ./qupath/apps --download-path ./qupath/download ${{ matrix.qupath-version }} | grep -v "^#" | sed "s/^/PAQUO_QUPATH_DIR=/" >> $GITHUB_ENV
     - name: Test with pytest
       run: |
         pytest --cov=./paquo --cov-report=xml

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   # RUN PYTEST ON PAQUO SOURCE
   tests:
-    name: pytest ${{ matrix.os }}::py${{ matrix.python-version }}
+    name: pytest ${{ matrix.os }}::qp${{ matrix.qupath-version }}::py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 8

--- a/paquo/classes.py
+++ b/paquo/classes.py
@@ -83,7 +83,7 @@ class QuPathPathClass:
         if color is not None:
             java_color = QuPathColor.from_any(color).to_java_rgba()  # use rgba?
 
-        if compatibility.supports_newer_addobject_and_pathclass():
+        if compatibility.supports_newer_addobject_and_pathclass:
             path_class = PathClass.getInstance(java_parent, name, java_color)
         else:
             path_class = PathClassFactory.getDerivedPathClass(java_parent, name, java_color)

--- a/paquo/hierarchy.py
+++ b/paquo/hierarchy.py
@@ -450,6 +450,7 @@ class QuPathPathObjectHierarchy:
             raise TypeError("requires a geojson list")
 
         requires_annotation_json_fix = compatibility.requires_annotation_json_fix
+        requires_objecttype_json_fix = compatibility.requires_objecttype_json_fix
 
         aos = []
         skipped: "CounterType[str]" = collections.Counter()
@@ -486,6 +487,12 @@ class QuPathPathObjectHierarchy:
                         _logger.warn(f"annotation has incompatible object_type: '{object_type}'")
                         object_id = "PathAnnotationObject"
                     annotation['id'] = object_id
+
+                if (
+                    requires_objecttype_json_fix
+                    and 'object_type' not in properties
+                ):
+                    properties['object_type'] = object_type
 
                 gson = GsonTools.getInstance()
                 if object_type == "annotation":

--- a/paquo/hierarchy.py
+++ b/paquo/hierarchy.py
@@ -109,8 +109,12 @@ class PathObjectProxy(Sequence[PathROIObjectType], MutableSet[PathROIObjectType]
         if self._readonly:
             raise OSError("project in readonly mode")
         path_objects = [x.java_object for x in other]
+        if compatibility.supports_addobjects:
+            add_objects = self._java_hierarchy.addObjects
+        else:
+            add_objects = self._java_hierarchy.addPathObjects
         try:
-            self._java_hierarchy.addPathObjects(path_objects)
+            add_objects(path_objects)
         finally:
             self._list_invalidate_cache()
         return self
@@ -128,7 +132,7 @@ class PathObjectProxy(Sequence[PathROIObjectType], MutableSet[PathROIObjectType]
             self._list_invalidate_cache()
         return self
 
-    if compatibility.supports_newer_addobject_and_pathclass():
+    if compatibility.supports_newer_addobject_and_pathclass:
         def add(self, x: PathROIObjectType) -> None:
             """adds a new path object to the proxy"""
             if self._mask:
@@ -445,7 +449,7 @@ class QuPathPathObjectHierarchy:
         if not isinstance(geojson, list):
             raise TypeError("requires a geojson list")
 
-        requires_annotation_json_fix = compatibility.requires_annotation_json_fix()
+        requires_annotation_json_fix = compatibility.requires_annotation_json_fix
 
         aos = []
         skipped: "CounterType[str]" = collections.Counter()

--- a/paquo/java.py
+++ b/paquo/java.py
@@ -63,6 +63,14 @@ class _Compatibility:
             return self.version <= QuPathVersion("0.2.3")
 
     @cached_property
+    def requires_objecttype_json_fix(self) -> bool:
+        # annotations changed between QuPath "0.3.0" and "0.4.x"
+        if self.version is None:
+            return False
+        else:
+            return QuPathVersion("0.3.0") <= self.version < QuPathVersion("0.4.0")
+
+    @cached_property
     def supports_image_server_recovery(self) -> bool:
         # image_server server.json files are only guaranteed to be written since QuPath "0.2.0"
         # see: https://github.com/qupath/qupath/commit/39abee3012da9252ea988308848c5d802164e060

--- a/paquo/java.py
+++ b/paquo/java.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import cached_property
 
 from paquo._config import settings
 from paquo._config import to_kwargs
@@ -43,6 +44,7 @@ class _Compatibility:
     def __init__(self, version: "QuPathVersion | None") -> None:
         self.version = version
 
+    @cached_property
     def requires_missing_classes_json_fix(self) -> bool:
         # older QuPaths crash on project load when classes.json is missing
         # see: https://github.com/qupath/qupath/commit/be861cea80b9a8ef300e30d7985fd69791c2432e
@@ -51,6 +53,7 @@ class _Compatibility:
         else:
             return self.version <= QuPathVersion("0.2.0")
 
+    @cached_property
     def requires_annotation_json_fix(self) -> bool:
         # annotations changed between QuPath "0.2.3" and "0.3.x"
         # see: https://github.com/qupath/qupath/commit/fef5c43ce3f67e0e062677c407b395ef3e6e27c3
@@ -59,6 +62,7 @@ class _Compatibility:
         else:
             return self.version <= QuPathVersion("0.2.3")
 
+    @cached_property
     def supports_image_server_recovery(self) -> bool:
         # image_server server.json files are only guaranteed to be written since QuPath "0.2.0"
         # see: https://github.com/qupath/qupath/commit/39abee3012da9252ea988308848c5d802164e060
@@ -67,6 +71,7 @@ class _Compatibility:
         else:
             return self.version >= QuPathVersion("0.2.0")
 
+    @cached_property
     def supports_logmanager(self) -> bool:
         # the logmanager class was only added with 0.2.0-m10
         # see: https://github.com/qupath/qupath/commit/15b844703b686f7a9a64c50194ebe22fc46924a5
@@ -75,6 +80,7 @@ class _Compatibility:
         else:
             return self.version >= QuPathVersion("0.2.0-m10")
 
+    @cached_property
     def supports_newer_addobject_and_pathclass(self) -> bool:
         # PathObjectHierarchy.addPathObject and .addPathObjectWithoutUpdate are deprecated
         # PathClassFactory is deprecated too
@@ -83,6 +89,30 @@ class _Compatibility:
             return False
         else:
             return self.version >= QuPathVersion("0.4.0")
+
+    @cached_property
+    def supports_addobjects(self) -> bool:
+        # PathObjectHierarchy.addPathObjects was removed
+        if self.version is None:
+            return False
+        else:
+            return self.version >= QuPathVersion("0.6.0")
+
+    @cached_property
+    def supports_get_uris(self) -> bool:
+        # .getServerURIs was removed
+        if self.version is None:
+            return False
+        else:
+            return self.version >= QuPathVersion("0.6.0")
+
+    @cached_property
+    def supports_newer_measurements_interface(self) -> bool:
+        # .putMeasurement is gone?
+        if self.version is None:
+            return False
+        else:
+            return self.version >= QuPathVersion("0.6.0")
 
 
 compatibility = _Compatibility(qupath_version)
@@ -112,7 +142,7 @@ ImageServer = JClass('qupath.lib.images.servers.ImageServer')
 ImageServers = JClass('qupath.lib.images.servers.ImageServers')  # NOTE: this is needed to make QuPath v0.3.0-rc1 work
 ImageServerProvider = JClass('qupath.lib.images.servers.ImageServerProvider')
 
-if compatibility.supports_logmanager():
+if compatibility.supports_logmanager:
     LogManager = JClass('qupath.lib.gui.logging.LogManager')
 else:
     LogManager = None
@@ -120,7 +150,7 @@ else:
 PathAnnotationObject = JClass("qupath.lib.objects.PathAnnotationObject")
 PathClass = JClass('qupath.lib.objects.classes.PathClass')
 
-if not compatibility.supports_newer_addobject_and_pathclass():
+if not compatibility.supports_newer_addobject_and_pathclass:
     PathClassFactory = JClass('qupath.lib.objects.classes.PathClassFactory')
 else:
     PathClassFactory = None
@@ -157,6 +187,7 @@ NegativeArraySizeException = JClass('java.lang.NegativeArraySizeException')
 IllegalArgumentException = JClass('java.lang.IllegalArgumentException')
 FileNotFoundException = JClass('java.io.FileNotFoundException')
 NoSuchFileException = JClass('java.nio.file.NoSuchFileException')
+RuntimeException = JClass('java.lang.RuntimeException')
 
 
 def __getattr__(name):

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -219,7 +219,7 @@ class QuPathProject:
 
         if _exists:
             cm: Callable[..., ContextManager[Any]]
-            if compatibility.requires_missing_classes_json_fix():
+            if compatibility.requires_missing_classes_json_fix:
                 @contextmanager
                 def cm(is_readonly):
                     classes_json = p.parent.joinpath("classifiers", "classes.json")
@@ -453,8 +453,12 @@ class QuPathProject:
                 uri2uri[URI(old_uri)] = URI(new_uri)
 
         # update uris if possible
-        for image in self.images:
-            image.java_object.updateServerURIs(uri2uri)
+        if compatibility.supports_get_uris:
+            for image in self.images:
+                image.java_object.updateURIs(uri2uri)
+        else:
+            for image in self.images:
+                image.java_object.updateServerURIs(uri2uri)
 
     @redirect(stderr=True, stdout=True)
     def remove_image(

--- a/paquo/tests/test_images.py
+++ b/paquo/tests/test_images.py
@@ -175,7 +175,7 @@ def test_readonly_recovery_hierarchy(project_with_removed_image_without_image_da
 
 def test_readonly_recovery_image_server(project_with_removed_image):
     from paquo.java import compatibility
-    if not compatibility.supports_image_server_recovery():
+    if not compatibility.supports_image_server_recovery:
         pytest.skip(f"unsupported in {compatibility.version}")
 
     with QuPathProject(project_with_removed_image, mode='r') as qp:

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -316,7 +316,7 @@ def test_project_delete_image_file_when_opened(new_project, svs_small, qupath_ve
     elif qupath_uses == "OPENSLIDE":
 
         if (
-            qupath_version >= QuPathVersion("0.5.0")
+            QuPathVersion("0.5.0") <= qupath_version < QuPathVersion("0.6.0")
             and platform.system() == "Windows"
         ):
             cm = pytest.raises(PermissionError)

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -299,7 +299,7 @@ def test_project_delete_image_file_when_opened(new_project, svs_small, qupath_ve
     qupath_uses = "OPENSLIDE"
 
     if qupath_uses == "BIOFORMATS":  # pragma: no cover
-        if platform.system() == "Windows":
+        if platform.system() == "Windows" and qupath_version < QuPathVersion("0.6.0"):
             # NOTE: on Windows because you can't delete files that have open
             #   file handles. In this test we're deleting the file opened by
             #   the ImageServer on the java side. (this is happening


### PR DESCRIPTION
This PR:
- adds support for `0.6.0` qupath
- adds tests against all supported qupath minor versions
- adds tests against `py3.13`
- fixes an json loading issue for TileObjects on qupath `0.3.x`

Close #125 